### PR TITLE
issue #6 Add the Player.PathFinding() function

### DIFF
--- a/Razor/RazorEnhanced/Player.cs
+++ b/Razor/RazorEnhanced/Player.cs
@@ -2,6 +2,8 @@ using Assistant;
 using Assistant.UI;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace RazorEnhanced
 {
@@ -2676,6 +2678,19 @@ namespace RazorEnhanced
         {
             Assistant.Point3D loc = new(x, y, z);
             PathFindToPacket(loc);
+        }
+
+        /// <summary>
+        /// Returns the pathfinding status of ClassicUO
+        /// </summary>
+        public static bool PathFinding()
+        {
+            var getAutoWalking = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Pathfinder")?.GetProperty("AutoWalking");
+
+            if (getAutoWalking == null)
+                return false;
+
+            return (bool)getAutoWalking.GetValue(null);
         }
 
         // Fly


### PR DESCRIPTION
issue #6 

There is a Player.PathFindTo function, but there is no Player.PathFinding() function.
This feature is useful for checking the Walking state

# Follow function
```
while followMobile is not None:  # Check if the follow target exists
    if Player.PathFind():  # Pathfinding check
        Player.PathFindTo(followMobile.Position)
```

If the Player.PathFind() function does not exist here, the Player.PathFindTo(follow.Position) will be repeatedly executed in the while loop, **causing CUO to freeze**