### PR TITLE
Draft: Use real Ctrl modifier for OSI Player.Run and pace path completion to client movement cadence

### DIFF
--- a/Razor/Client/OSIClient.cs
+++ b/Razor/Client/OSIClient.cs
@@ -1042,13 +1042,27 @@ namespace Assistant
 
         [DllImport("user32.dll")]
         internal static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll")]
+        internal static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+        private const uint WM_KEYDOWN = 0x100;
+        private const uint WM_KEYUP = 0x101;
+        private const int VK_CONTROL = 0x11;
+        private const uint KEYEVENTF_KEYUP = 0x0002;
+
         public void KeyPress(int keyCode)
         {
-            const uint WM_KEYDOWN = 0x100;
-            const uint WM_KEYUP = 0x101;
             SendMessage(FindUOWindow(), WM_KEYDOWN, (IntPtr)keyCode, (IntPtr)1);
             Thread.Sleep(10);
             SendMessage(FindUOWindow(), WM_KEYUP, (IntPtr)keyCode, (IntPtr)1);
+        }
+
+        public void KeyChord(int modifierKeyCode, int keyCode)
+        {
+            keybd_event((byte)modifierKeyCode, 0, 0, UIntPtr.Zero);
+            Thread.Sleep(10);
+            KeyPress(keyCode);
+            Thread.Sleep(10);
+            keybd_event((byte)modifierKeyCode, 0, KEYEVENTF_KEYUP, UIntPtr.Zero);
         }
 
         public void KeySend(string keys)
@@ -1115,56 +1129,41 @@ namespace Assistant
         internal bool RequestMove(Direction m_Dir, bool run)
         {
             int keyToPress = 0;
-            string keyToSend = "";
-            if (run)
-            {
-                keyToSend += "^";
-            }
-
             switch (m_Dir)
             {
                 case Direction.down:
                     keyToPress = (int)KeyboardDir.Down;
-                    keyToSend += "{DOWN}";
                     break;
                 case Direction.east:
                     keyToPress = (int)KeyboardDir.East;
-                    keyToSend += "{PGDN}";
                     break;
                 case Direction.left:
                     keyToPress = (int)KeyboardDir.Left;
-                    keyToSend += "{Left}";
                     break;
                 case Direction.north:
                     keyToPress = (int)KeyboardDir.North;
-                    keyToSend += "{PGUP}";
                     break;
                 case Direction.right:
                     keyToPress = (int)KeyboardDir.Right;
-                    keyToSend += "{RIGHT}";
                     break;
                 case Direction.south:
                     keyToPress = (int)KeyboardDir.South;
-                    keyToSend += "{END}";
                     break;
                 case Direction.up:
                     keyToPress = (int)KeyboardDir.Up;
-                    keyToSend += "{UP}";
                     break;
                 case Direction.west:
                     keyToPress = (int)KeyboardDir.West;
-                    keyToSend += "{HOME}";
                     break;
                 default:
                     keyToPress = (int)KeyboardDir.Up;
-                    keyToSend += "{UP}";
                     break;
             }
 
             World.Player.WalkScriptRequest = 1;
             if (run)
             {
-                KeySend(keyToSend);  // this is only way I can send ctrl- and it forces focus to UO window
+                KeyChord(VK_CONTROL, keyToPress);
             }
             else
             {

--- a/Razor/RazorEnhanced/PathFinding.cs
+++ b/Razor/RazorEnhanced/PathFinding.cs
@@ -1066,6 +1066,14 @@ namespace RazorEnhanced
             return followPath(false, timeout, debugMessage, useResync);
         }
 
+        private static void WaitForStepSettle(bool run)
+        {
+            // OSI movement state is updated optimistically from movement packets, which can
+            // get ahead of the visible client animation. Running via direct key messages made
+            // that timing gap more obvious, so add a small settle delay after accepted moves.
+            Misc.Pause(run ? 100 : 200);
+        }
+
         internal static List<Tile> BypassItem(List<Tile> path, int i)
         {
             int j = i;
@@ -1322,11 +1330,14 @@ namespace RazorEnhanced
                     {
                         if (debugMessage)
                             Misc.SendMessage("PathFind: Move action OK", 66);
+
+                        WaitForStepSettle(run);
                     }
                 }
 
                 if (Player.Position.X == dst.X && Player.Position.Y == dst.Y)
                 {
+                    WaitForStepSettle(run);
                     Misc.SendMessage("PathFind: Destination reached", 66);
                     Misc.Resync();
                     return true;
@@ -1373,5 +1384,3 @@ namespace RazorEnhanced
         }
     }
 }
-
-


### PR DESCRIPTION
## Summary

This fixes scripted `Player.Run(...)` on the OSI client in environments where the previous `SendKeys("^...")` path is unreliable, especially under Wine/Wayland.

It also adjusts `PathFinding.RunPath` / `WalkPath` completion pacing so script-side movement completion better matches the client's visible movement cadence.

## Problem

`Player.Walk(...)` was working, but `Player.Run(...)` was not.

The root cause was that the OSI movement paths were not equivalent:

- `Walk` used direct window key messages
- `Run` used `SendKeys("^...")`, which depends on focus stealing and synthesized keyboard input

That was fragile under Wayland/Hyprland and Wine.

A first attempt to replace `SendKeys` with direct `Ctrl + Direction` window messages still failed, because the OSI hook checks modifier state using `GetAsyncKeyState(VK_CONTROL)`. Posted key messages alone do not establish real async modifier state, so the client still interpreted the movement as walking.

## What changed

### OSI run input

`OSIClient.RequestRun(...)` now:

- establishes a real `Ctrl` modifier state via `keybd_event`
- sends the direction key via the existing direct window-message path
- releases `Ctrl` afterwards

This avoids the old `SendKeys` dependency while still satisfying the OSI client's modifier-state check.

### Path timing

`PathFinding.followPath(...)` now adds a small post-step settle delay after accepted movement so `"Destination reached"` and per-step success timing better match what the client visibly does.

Current delays are based on measured client cadence:

- run: `100 ms`
- walk: `200 ms`

## Validation

Observed client benchmarks:

- run: about `100.33 ms/tile` (`~9.97 tiles/sec`)
- walk: about `198.27 ms/tile` (`~5.04 tiles/sec`)

Manual verification also confirmed that scripted run input started working again after switching to a real modifier-state event.

## Review requested

Please review and test this change on native Windows as well.

This work was validated under Wine/Wayland, but native Windows verification was not completed yet. In particular, it would be useful to confirm:

- `Player.Run(...)` still behaves correctly on OSI under Windows
- no input regressions were introduced for scripted movement
- the updated `RunPath` / `WalkPath` timing still feels correct on Windows

## Notes

- This change is targeted at the OSI client path.
- `PathFinding` pacing was tuned from measured OSI behavior to reduce script/UI timing mismatch.