### PR TITLE
Added in a location sub taq to the filters tab. this tab will allow y…

### DIFF
--- a/Razor/Core/Item.cs
+++ b/Razor/Core/Item.cs
@@ -1125,28 +1125,62 @@ namespace Assistant
         }
         void UpdateProperties()
         {
-            try
+            if (Engine.MainWindow.DisplayXYUnderMapCheckBox.Checked)
             {
-                Utility.Logger.Debug("{0} for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
-                if (MapItemHistory.ContainsKey(Serial))
+                try
                 {
-                    Utility.Logger.Debug("{0} has MapHistory for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
-                    int xCoord = MapOrigin.X + (int)(Multiplier * PinPosition.X);
-                    int yCoord = MapOrigin.Y + (int)(Multiplier * PinPosition.Y);
-                    string location = String.Format("({0}, {1})",
-                        xCoord,
-                        yCoord
-                        );
-                    m_ObjPropList.AddOrReplace(new Assistant.ObjectPropertyList.OPLEntry(1061114, location));
+                    Utility.Logger.Debug("{0} for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
+                    if (MapItemHistory.ContainsKey(Serial))
+                    {
+                        Utility.Logger.Debug("{0} has MapHistory for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
+                        int xCoord = MapOrigin.X + (int)(Multiplier * PinPosition.X);
+                        int yCoord = MapOrigin.Y + (int)(Multiplier * PinPosition.Y);
+                        string location = String.Format("({0}, {1})",
+                            xCoord,
+                            yCoord
+                            );
+
+
+                        if (Engine.MainWindow.CaptureTmapsCheckBox.Checked)
+                        {
+                            string tmapCapturePath = RazorEnhanced.Settings.General.ReadString("TmapCapturePath");
+                            string tmapLog;
+                            if (!string.IsNullOrEmpty(tmapCapturePath))
+                                tmapLog = Path.Combine(tmapCapturePath, "TreasureMapCapture.csv");
+                            else
+                                tmapLog = Path.Combine(Assistant.Engine.RootPath, "TreasureMapCapture.csv");
+
+                            string entry = $"{xCoord},{yCoord},{Facet},treasure map,interest,red,3";
+
+                            bool alreadyExists = false;
+                            if (File.Exists(tmapLog))
+                            {
+                                string existingContent = File.ReadAllText(tmapLog);
+                                alreadyExists = existingContent.Contains(entry);
+                            }
+
+                            if (!alreadyExists)
+                            {
+                                using (StreamWriter sw = File.AppendText(tmapLog))
+                                {
+                                    sw.WriteLine(entry);
+                                }
+
+                                World.Player.SendMessage(MsgLevel.Force, $"TMAP Captured: {xCoord},{yCoord}");
+                            }
+                        }
+
+                        m_ObjPropList.AddOrReplace(new Assistant.ObjectPropertyList.OPLEntry(1061114, location));
+                    }
+                    else
+                    {
+                        Utility.Logger.Debug("{0} No has MapHistory for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
+                    }
                 }
-                else
+                catch (Exception)
                 {
-                    Utility.Logger.Debug("{0} No has MapHistory for {1:X}", System.Reflection.MethodBase.GetCurrentMethod().Name, Serial);
+                    m_ObjPropList.AddOrReplace(new Assistant.ObjectPropertyList.OPLEntry(1061114, "Error"));
                 }
-            }
-            catch (Exception)
-            {
-                m_ObjPropList.AddOrReplace(new Assistant.ObjectPropertyList.OPLEntry(1061114, "Error"));
             }
             Assistant.Client.Instance.SendToClient(new ObjectProperties(Serial, ObjPropList));
 

--- a/Razor/Core/MessageInBottleCapture.cs
+++ b/Razor/Core/MessageInBottleCapture.cs
@@ -20,6 +20,7 @@ using RazorEnhanced;
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Assistant.Core
 {
@@ -111,12 +112,18 @@ namespace Assistant.Core
             return $"[Location: {xAxis}, {yAxis}]";
         }
 
+        private static readonly Regex _coordPattern = new Regex(
+            @"(\d+)°(\d+)'([NS])\s*,\s*(\d+)°(\d+)'([EW])",
+            RegexOptions.Compiled);
+
         private static void ConvertCoords(string coords, ref int xAxis, ref int yAxis)
         {
-            string[] coordsSplit = coords.Split(',');
+            Match match = _coordPattern.Match(coords);
+            if (!match.Success)
+                return;
 
-            string yCoord = coordsSplit[0];
-            string xCoord = coordsSplit[1];
+            string yCoord = match.Groups[1].Value + "°" + match.Groups[2].Value + "'" + match.Groups[3].Value;
+            string xCoord = match.Groups[4].Value + "°" + match.Groups[5].Value + "'" + match.Groups[6].Value;
 
             // Calc Y first
             string[] ySplit = yCoord.Split('°');

--- a/Razor/Core/MessageInBottleCapture.cs
+++ b/Razor/Core/MessageInBottleCapture.cs
@@ -1,0 +1,161 @@
+﻿#region license
+// Razor: An Ultima Online Assistant
+// Copyright (c) 2022 Razor Development Community on GitHub <https://github.com/markdwags/Razor>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#endregion
+
+using RazorEnhanced;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Assistant.Core
+{
+    public class MessageInBottleCapture
+    {
+        private static readonly string[] _mibGumpLayout =
+        {
+            "{ page 0 }{ resizepic 0 40 2520 350 300 }{ xmfhtmlgump 30 80 285 160 1018326 1 1 }{ htmlgump 35 240 230 20 0 0 0 }{ button 35 265 4005 4007 1 0 0 }{ xmfhtmlgump 70 265 100 20 1011036 0 0 }",
+            "{ page 0 }{ htmlgump 200 140 230 20 0 0 0 }{ resizepic 0 40 2520 350 300 }{ xmfhtmlgump 30 80 285 160 1018326 1 1 }{ htmlgump 35 240 230 20 1 0 0 }{ button 35 265 4005 4007 1 0 0 }{ xmfhtmlgump 70 265 100 20 1011036 0 0 }"
+        };
+
+        public static bool IsMibGump(string layout)
+        {
+            return _mibGumpLayout.Any(
+                gumpLayout => layout.IndexOf(gumpLayout, StringComparison.OrdinalIgnoreCase) != -1);
+        }
+
+        public static void CaptureMibCoordinates(string coords)
+        {
+            string mibCapturePath = RazorEnhanced.Settings.General.ReadString("MibCapturePath");
+            string mibLog;
+            if (!string.IsNullOrEmpty(mibCapturePath))
+                mibLog = Path.Combine(mibCapturePath, "MIBCapture.csv");
+            else
+                mibLog = Path.Combine(Assistant.Engine.RootPath, "MIBCapture.csv");
+
+            // 130°15'N,63°16'W
+
+            int xAxis = 0;
+            int yAxis = 0;
+
+            // Auto-detect format: if contains '|', treat as x|y, else as latitude/longitude
+            if (coords.Contains("|"))
+            {
+                // 0   1 2
+                // MIB|x|y
+                string[] mibCoords = coords.Split('|');
+                if (mibCoords.Length >= 3)
+                {
+                    int.TryParse(mibCoords[1], out xAxis);
+                    int.TryParse(mibCoords[2], out yAxis);
+                }
+            }
+            else
+            {
+                ConvertCoords(coords, ref xAxis, ref yAxis);
+            }
+
+            string entry = $"{xAxis},{yAxis},{World.Player.Map},mib,mib,red,3";
+
+            bool alreadyExists = false;
+            if (File.Exists(mibLog))
+            {
+                string existingContent = File.ReadAllText(mibLog);
+                alreadyExists = existingContent.Contains(entry);
+            }
+
+            if (!alreadyExists)
+            {
+                using (StreamWriter sw = File.AppendText(mibLog))
+                {
+                    sw.WriteLine(entry);
+                }
+
+                World.Player.SendMessage(MsgLevel.Force, $"MIB Captured: {xAxis},{yAxis}");
+            }
+        }
+
+
+        public static string GetMibCoordinatesLabel(string coords)
+        {
+            int xAxis = 0;
+            int yAxis = 0;
+
+            if (coords.Contains("|"))
+            {
+                string[] mibCoords = coords.Split('|');
+                if (mibCoords.Length >= 3)
+                {
+                    int.TryParse(mibCoords[1], out xAxis);
+                    int.TryParse(mibCoords[2], out yAxis);
+                }
+            }
+            else
+            {
+                ConvertCoords(coords, ref xAxis, ref yAxis);
+            }
+
+            return $"[Location: {xAxis}, {yAxis}]";
+        }
+
+        private static void ConvertCoords(string coords, ref int xAxis, ref int yAxis)
+        {
+            string[] coordsSplit = coords.Split(',');
+
+            string yCoord = coordsSplit[0];
+            string xCoord = coordsSplit[1];
+
+            // Calc Y first
+            string[] ySplit = yCoord.Split('°');
+            double yDegree = Convert.ToDouble(ySplit[0]);
+            double yMinute = Convert.ToDouble(ySplit[1].Substring(0, ySplit[1].IndexOf("'", StringComparison.Ordinal)));
+
+            if (yCoord.Substring(yCoord.Length - 1).Equals("N"))
+            {
+                yAxis = (int)(1624 - (yMinute / 60) * (4096.0 / 360) - yDegree * (4096.0 / 360));
+            }
+            else
+            {
+                yAxis = (int)(1624 + (yMinute / 60) * (4096.0 / 360) + yDegree * (4096.0 / 360));
+            }
+
+            // Calc X next
+            string[] xSplit = xCoord.Split('°');
+            double xDegree = Convert.ToDouble(xSplit[0]);
+            double xMinute = Convert.ToDouble(xSplit[1].Substring(0, xSplit[1].IndexOf("'", StringComparison.Ordinal)));
+
+            if (xCoord.Substring(xCoord.Length - 1).Equals("W"))
+            {
+                xAxis = (int)(1323 - (xMinute / 60) * (5120.0 / 360) - xDegree * (5120.0 / 360));
+            }
+            else
+            {
+                xAxis = (int)(1323 + (xMinute / 60) * (5120.0 / 360) + xDegree * (5120.0 / 360));
+            }
+
+            // Normalize values outside of map range.
+            if (xAxis < 0)
+                xAxis += 5120;
+            else if (xAxis > 5120)
+                xAxis -= 5120;
+
+            if (yAxis < 0)
+                yAxis += 4096;
+            else if (yAxis > 4096)
+                yAxis -= 4096;
+        }
+    }
+}

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -157,12 +157,30 @@ namespace Assistant
                         {
                             Item item = World.FindItem(s);
                             if (item == null)
+                            {
                                 return;
-
+                            }
                             item.ReadPropertyList(p);
                             item.PropsUpdated = true;
                             if (item is MapItem)
                             {
+                                args.Block = true;
+                                Assistant.Client.Instance.SendToClient(new ObjectProperties(item.Serial, item.ObjPropList));
+                            }
+                            else if((item.TypeID == 0x14EB || item.TypeID == 0x14EC))
+                            {
+                                if (MapItem.MapItemHistory.ContainsKey(s))
+                                {
+                                    MapItem historical = MapItem.MapItemHistory[s];
+                                    if (Engine.MainWindow.DisplayXYUnderMapCheckBox.Checked)
+                                    {
+                                        int xCoord = historical.MapOrigin.X + (int)(MapItem.Multiplier * historical.PinPosition.X);
+                                        int yCoord = historical.MapOrigin.Y + (int)(MapItem.Multiplier * historical.PinPosition.Y);
+                                        string location = String.Format("({0}, {1})", xCoord, yCoord);
+                                        item.ObjPropList.AddOrReplace(new Assistant.ObjectPropertyList.OPLEntry(1061114, location));
+                                    }
+                                }
+
                                 args.Block = true;
                                 Assistant.Client.Instance.SendToClient(new ObjectProperties(item.Serial, item.ObjPropList));
                             }
@@ -3536,16 +3554,49 @@ namespace Assistant
                     List<string> parsedStrings = ParseGumpString(gumpPieces, stringlistparse);
                     dataInGump.AddRange(parsedStrings);
                     World.Player.CurrentGumpStrings.AddRange(parsedStrings);
-
                 }
+
+                if (Assistant.MainForm.MibGumpIds.Contains(currentgumpi))
+                {
+                    string locationLabel = null;
+                    for (int i = 0; i < dataInGump.Count; i++)
+                    {
+                        if (Engine.MainWindow.CaptureMibsCheckBox.Checked)
+                            Assistant.Core.MessageInBottleCapture.CaptureMibCoordinates(dataInGump[i]);
+
+                        if (Engine.MainWindow.AddXYToGumpCheckBox.Checked && locationLabel == null)
+                            locationLabel = Assistant.Core.MessageInBottleCapture.GetMibCoordinatesLabel(dataInGump[i]);
+                    }
+
+                    if (locationLabel != null)
+                    {
+                        int textIndex = stringlistparse.Length;
+                        // Expand string list to add our label
+                        string[] newStringList = new string[textIndex + 1];
+                        Array.Copy(stringlistparse, newStringList, textIndex);
+                        newStringList[textIndex] = locationLabel;
+                        stringlistparse = newStringList;
+
+                        // Add a text element to the layout: text [x] [y] [color] [text-id]
+                        layout += String.Format("{{ text 150 240 0 {0} }}", textIndex);
+
+                        // Block original and send modified gump
+                        args.Block = true;
+                        List<string> gumpStrings = new();
+                        for (int i = 0; i < stringlistparse.Length; i++)
+                        {
+                            gumpStrings.Add(stringlistparse[i] ?? "");
+                        }
+                        Assistant.Client.Instance.SendToClient(new GenericGump(currentgumpi, currentgumps, (uint)x, (uint)y, layout, gumpStrings));
+                    }
+                }
+
                 RazorEnhanced.GumpInspector.NewGumpCompressedAddLog(currentgumps, currentgumpi);
 
                 RazorEnhanced.Gumps.AddGump(currentgumps, currentgumpi);
 
                 RazorEnhanced.Macros.MacroManager.RecordAction(new RazorEnhanced.Macros.Actions.WaitForGumpAction(currentgumpi, 10000));
                 
-
-
                 RazorEnhanced.Gumps.AddResponse(currentgumpi, x, y, layout, textsInGump, dataInGump, stringlistparse, gumpPieces);
                 World.Player.CurrentGumpRawLayout = layout; // Get raw data of current gump
                 World.Player.CurrentGumpRawText = stringlistparse; // Get raw text data of current gump

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -3558,6 +3558,7 @@ namespace Assistant
 
                 if (Assistant.MainForm.MibGumpIds.Contains(currentgumpi))
                 {
+                    Misc.SendMessage("checking gump for mib data to capture.");
                     string locationLabel = null;
                     for (int i = 0; i < dataInGump.Count; i++)
                     {

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -3558,7 +3558,6 @@ namespace Assistant
 
                 if (Assistant.MainForm.MibGumpIds.Contains(currentgumpi))
                 {
-                    Misc.SendMessage("checking gump for mib data to capture.");
                     string locationLabel = null;
                     for (int i = 0; i < dataInGump.Count; i++)
                     {

--- a/Razor/Razor.csproj
+++ b/Razor/Razor.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -409,6 +409,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Core\BuffInfo.cs" />
+    <Compile Include="Core\MessageInBottleCapture.cs" />
     <Compile Include="Enums\TargetFlags.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Network\PacketLogger.cs" />
@@ -777,6 +778,9 @@
     </Compile>
     <Compile Include="UI\Ext.cs" />
     <Compile Include="UI\Filter\EN-Filters.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\Filter\LocationsFilter.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="UI\Agent\Friends.cs">

--- a/Razor/RazorEnhanced/Filters.cs
+++ b/Razor/RazorEnhanced/Filters.cs
@@ -716,6 +716,15 @@ namespace RazorEnhanced
             AutoRemountSerial = Settings.General.ReadInt("MountSerial");
             MinDamageDisplayed = RazorEnhanced.Settings.General.ReadInt("LimitDamageDisplayValue");
 
+            // Locations tab
+            Engine.MainWindow.CaptureMibsCheckBox.Checked = Settings.General.ReadBool("CaptureMibsCheckBox");
+            Engine.MainWindow.MibPathTextBox.Text = Settings.General.ReadString("MibCapturePath");
+            Engine.MainWindow.AddXYToGumpCheckBox.Checked = Settings.General.ReadBool("AddXYToGumpCheckBox");
+            Engine.MainWindow.LoadMibGumpIds();
+            Engine.MainWindow.CaptureTmapsCheckBox.Checked = Settings.General.ReadBool("CaptureTmapsCheckBox");
+            Engine.MainWindow.TmapPathTextBox.Text = Settings.General.ReadString("TmapCapturePath");
+            Engine.MainWindow.DisplayXYUnderMapCheckBox.Checked = Settings.General.ReadBool("DisplayXYUnderMapCheckBox");
+
             InitGraphGrid();
             InitJournalFilterGrid();
         }

--- a/Razor/RazorEnhanced/Settings.cs
+++ b/Razor/RazorEnhanced/Settings.cs
@@ -2325,6 +2325,15 @@ namespace RazorEnhanced
             general.Columns.Add("ColorFlagsSelfHighlightCheckBox", typeof(bool));
             general.Columns.Add("LimitDamageDisplayValue", typeof(int));
 
+            // Parametri Tab (Locations Filter)
+            general.Columns.Add("CaptureMibsCheckBox", typeof(bool));
+            general.Columns.Add("MibCapturePath", typeof(string));
+            general.Columns.Add("AddXYToGumpCheckBox", typeof(bool));
+            general.Columns.Add("MibGumpIds", typeof(string));
+            general.Columns.Add("CaptureTmapsCheckBox", typeof(bool));
+            general.Columns.Add("TmapCapturePath", typeof(string));
+            general.Columns.Add("DisplayXYUnderMapCheckBox", typeof(bool));
+
 
             // Parametri Tab (Enhanced ToolBar)
             general.Columns.Add("LockToolBarCheckBox", typeof(bool));
@@ -5548,6 +5557,33 @@ namespace RazorEnhanced
                 general.Columns.Add("RemoteControl", typeof(bool));
                 RazorEnhanced.Settings.General.WriteBool("RemoteControl", false);
                 realVersion = 19;
+                General.WriteInt("SettingVersion", realVersion);
+            }
+            if (realVersion == 19)
+            {
+                DataTable general = m_Dataset.Tables["GENERAL"];
+                if (!general.Columns.Contains("CaptureMibsCheckBox"))
+                    general.Columns.Add("CaptureMibsCheckBox", typeof(bool));
+                if (!general.Columns.Contains("MibCapturePath"))
+                    general.Columns.Add("MibCapturePath", typeof(string));
+                if (!general.Columns.Contains("AddXYToGumpCheckBox"))
+                    general.Columns.Add("AddXYToGumpCheckBox", typeof(bool));
+                if (!general.Columns.Contains("MibGumpIds"))
+                    general.Columns.Add("MibGumpIds", typeof(string));
+                if (!general.Columns.Contains("CaptureTmapsCheckBox"))
+                    general.Columns.Add("CaptureTmapsCheckBox", typeof(bool));
+                if (!general.Columns.Contains("TmapCapturePath"))
+                    general.Columns.Add("TmapCapturePath", typeof(string));
+                if (!general.Columns.Contains("DisplayXYUnderMapCheckBox"))
+                    general.Columns.Add("DisplayXYUnderMapCheckBox", typeof(bool));
+                RazorEnhanced.Settings.General.WriteBool("CaptureMibsCheckBox", false);
+                RazorEnhanced.Settings.General.WriteString("MibCapturePath", "");
+                RazorEnhanced.Settings.General.WriteBool("AddXYToGumpCheckBox", false);
+                RazorEnhanced.Settings.General.WriteString("MibGumpIds", "");
+                RazorEnhanced.Settings.General.WriteBool("CaptureTmapsCheckBox", false);
+                RazorEnhanced.Settings.General.WriteString("TmapCapturePath", "");
+                RazorEnhanced.Settings.General.WriteBool("DisplayXYUnderMapCheckBox", false);
+                realVersion = 20;
                 General.WriteInt("SettingVersion", realVersion);
             }
             {

--- a/Razor/UI/Filter/LocationsFilter.cs
+++ b/Razor/UI/Filter/LocationsFilter.cs
@@ -1,0 +1,174 @@
+using RazorEnhanced;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Assistant
+{
+    public partial class MainForm : System.Windows.Forms.Form
+    {
+        internal CheckBox CaptureMibsCheckBox { get { return captureMibsCheckBox; } }
+        internal TextBox MibPathTextBox { get { return mibPathTextBox; } }
+        internal CheckBox AddXYToGumpCheckBox { get { return addXYToGumpCheckBox; } }
+        internal CheckBox CaptureTmapsCheckBox { get { return captureTmapsCheckBox; } }
+        internal TextBox TmapPathTextBox { get { return tmapPathTextBox; } }
+        internal CheckBox DisplayXYUnderMapCheckBox { get { return displayXYUnderMapCheckBox; } }
+        internal ListBox MibGumpIdListBox { get { return mibGumpIdListBox; } }
+
+        private static readonly List<uint> m_MibGumpIds = new List<uint>();
+        internal static List<uint> MibGumpIds { get { return m_MibGumpIds; } }
+
+        private const uint DefaultMibGumpId = 1426736667;
+
+        private void captureMibsCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (captureMibsCheckBox.Focused)
+                RazorEnhanced.Settings.General.WriteBool("CaptureMibsCheckBox", captureMibsCheckBox.Checked);
+        }
+
+        private void mibSetPathButton_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog folder = new FolderBrowserDialog
+            {
+                Description = "Select MIB Capture Folder",
+                SelectedPath = RazorEnhanced.Settings.General.ReadString("MibCapturePath"),
+                ShowNewFolderButton = true
+            };
+
+            if (folder.ShowDialog(this) == DialogResult.OK)
+            {
+                RazorEnhanced.Settings.General.WriteString("MibCapturePath", folder.SelectedPath);
+                mibPathTextBox.Text = folder.SelectedPath;
+            }
+        }
+
+        private void mibClearPathButton_Click(object sender, EventArgs e)
+        {
+            mibPathTextBox.Text = "";
+            RazorEnhanced.Settings.General.WriteString("MibCapturePath", "");
+        }
+
+        private void addXYToGumpCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (addXYToGumpCheckBox.Focused)
+                RazorEnhanced.Settings.General.WriteBool("AddXYToGumpCheckBox", addXYToGumpCheckBox.Checked);
+        }
+
+        private void mibGumpIdAddButton_Click(object sender, EventArgs e)
+        {
+            string text = mibGumpIdTextBox.Text.Trim();
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            uint gumpId;
+            if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!uint.TryParse(text.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out gumpId))
+                    return;
+            }
+            else
+            {
+                if (!uint.TryParse(text, out gumpId))
+                    return;
+            }
+
+            if (!m_MibGumpIds.Contains(gumpId))
+            {
+                m_MibGumpIds.Add(gumpId);
+                mibGumpIdListBox.Items.Add(gumpId.ToString());
+                SaveMibGumpIds();
+            }
+            mibGumpIdTextBox.Text = "";
+        }
+
+        private void mibGumpIdRemoveMenuItem_Click(object sender, EventArgs e)
+        {
+            if (mibGumpIdListBox.SelectedIndex < 0)
+                return;
+
+            string selected = mibGumpIdListBox.SelectedItem.ToString();
+            if (uint.TryParse(selected, out uint gumpId))
+            {
+                m_MibGumpIds.Remove(gumpId);
+            }
+            mibGumpIdListBox.Items.RemoveAt(mibGumpIdListBox.SelectedIndex);
+            SaveMibGumpIds();
+        }
+
+        internal void LoadMibGumpIds()
+        {
+            m_MibGumpIds.Clear();
+            mibGumpIdListBox.Items.Clear();
+
+            string stored = RazorEnhanced.Settings.General.ReadString("MibGumpIds");
+            if (string.IsNullOrEmpty(stored))
+            {
+                m_MibGumpIds.Add(DefaultMibGumpId);
+                mibGumpIdListBox.Items.Add(DefaultMibGumpId.ToString());
+                SaveMibGumpIds();
+            }
+            else
+            {
+                string[] parts = stored.Split(',');
+                foreach (string part in parts)
+                {
+                    if (uint.TryParse(part.Trim(), out uint id))
+                    {
+                        if (!m_MibGumpIds.Contains(id))
+                        {
+                            m_MibGumpIds.Add(id);
+                            mibGumpIdListBox.Items.Add(id.ToString());
+                        }
+                    }
+                }
+                if (m_MibGumpIds.Count == 0)
+                {
+                    m_MibGumpIds.Add(DefaultMibGumpId);
+                    mibGumpIdListBox.Items.Add(DefaultMibGumpId.ToString());
+                    SaveMibGumpIds();
+                }
+            }
+        }
+
+        private void SaveMibGumpIds()
+        {
+            string value = string.Join(",", m_MibGumpIds.Select(id => id.ToString()));
+            RazorEnhanced.Settings.General.WriteString("MibGumpIds", value);
+        }
+
+        private void captureTmapsCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (captureTmapsCheckBox.Focused)
+                RazorEnhanced.Settings.General.WriteBool("CaptureTmapsCheckBox", captureTmapsCheckBox.Checked);
+        }
+
+        private void displayXYUnderMapCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (displayXYUnderMapCheckBox.Focused)
+                RazorEnhanced.Settings.General.WriteBool("DisplayXYUnderMapCheckBox", displayXYUnderMapCheckBox.Checked);
+        }
+
+        private void tmapSetPathButton_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog folder = new FolderBrowserDialog
+            {
+                Description = "Select Treasure Map Capture Folder",
+                SelectedPath = RazorEnhanced.Settings.General.ReadString("TmapCapturePath"),
+                ShowNewFolderButton = true
+            };
+
+            if (folder.ShowDialog(this) == DialogResult.OK)
+            {
+                RazorEnhanced.Settings.General.WriteString("TmapCapturePath", folder.SelectedPath);
+                tmapPathTextBox.Text = folder.SelectedPath;
+            }
+        }
+
+        private void tmapClearPathButton_Click(object sender, EventArgs e)
+        {
+            tmapPathTextBox.Text = "";
+            RazorEnhanced.Settings.General.WriteString("TmapCapturePath", "");
+        }
+    }
+}

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -612,6 +612,25 @@ namespace Assistant
         private TabControl AdvancedPages;
         private TabControl TechnicalPages;
         private TabPage MiscFilterPage;
+        private TabPage locationsFilterPage;
+        private GroupBox sosGroupBox;
+        private System.Windows.Forms.CheckBox captureMibsCheckBox;
+        private System.Windows.Forms.TextBox mibPathTextBox;
+        private System.Windows.Forms.Button mibSetPathButton;
+        private System.Windows.Forms.Button mibClearPathButton;
+        private System.Windows.Forms.CheckBox addXYToGumpCheckBox;
+        private RazorEnhanced.UI.RazorAgentNumHexTextBox mibGumpIdTextBox;
+        private System.Windows.Forms.Button mibGumpIdAddButton;
+        private System.Windows.Forms.ListBox mibGumpIdListBox;
+        private System.Windows.Forms.GroupBox mibGumpIdGroupBox;
+        private System.Windows.Forms.ContextMenuStrip mibGumpIdContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem mibGumpIdRemoveMenuItem;
+        private GroupBox tmapGroupBox;
+        private System.Windows.Forms.CheckBox captureTmapsCheckBox;
+        private System.Windows.Forms.TextBox tmapPathTextBox;
+        private System.Windows.Forms.Button tmapSetPathButton;
+        private System.Windows.Forms.Button tmapClearPathButton;
+        private System.Windows.Forms.CheckBox displayXYUnderMapCheckBox;
         private GroupBox uomodgroupbox;
         private System.Windows.Forms.CheckBox uomodpaperdollCheckBox;
         private System.Windows.Forms.CheckBox uomodglobalsoundCheckBox;
@@ -984,6 +1003,25 @@ namespace Assistant
             this.targetaddTextBox = new System.Windows.Forms.TextBox();
             this.targetlistBox = new System.Windows.Forms.ListBox();
             this.MiscFilterPage = new System.Windows.Forms.TabPage();
+            this.locationsFilterPage = new System.Windows.Forms.TabPage();
+            this.sosGroupBox = new System.Windows.Forms.GroupBox();
+            this.captureMibsCheckBox = new System.Windows.Forms.CheckBox();
+            this.mibPathTextBox = new System.Windows.Forms.TextBox();
+            this.mibSetPathButton = new System.Windows.Forms.Button();
+            this.mibClearPathButton = new System.Windows.Forms.Button();
+            this.addXYToGumpCheckBox = new System.Windows.Forms.CheckBox();
+            this.mibGumpIdTextBox = new RazorEnhanced.UI.RazorAgentNumHexTextBox();
+            this.mibGumpIdAddButton = new System.Windows.Forms.Button();
+            this.mibGumpIdListBox = new System.Windows.Forms.ListBox();
+            this.mibGumpIdGroupBox = new System.Windows.Forms.GroupBox();
+            this.mibGumpIdContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mibGumpIdRemoveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tmapGroupBox = new System.Windows.Forms.GroupBox();
+            this.captureTmapsCheckBox = new System.Windows.Forms.CheckBox();
+            this.tmapPathTextBox = new System.Windows.Forms.TextBox();
+            this.tmapSetPathButton = new System.Windows.Forms.Button();
+            this.tmapClearPathButton = new System.Windows.Forms.Button();
+            this.displayXYUnderMapCheckBox = new System.Windows.Forms.CheckBox();
             this.DmgDsplyGroup = new System.Windows.Forms.GroupBox();
             this.minDmgShown = new RazorEnhanced.UI.RazorAgentNumOnlyTextBox();
             this.label81 = new System.Windows.Forms.Label();
@@ -1604,6 +1642,11 @@ namespace Assistant
             ((System.ComponentModel.ISupportInitialize)(this.targetbodydataGridView)).BeginInit();
             this.groupBox43.SuspendLayout();
             this.MiscFilterPage.SuspendLayout();
+            this.locationsFilterPage.SuspendLayout();
+            this.sosGroupBox.SuspendLayout();
+            this.mibGumpIdGroupBox.SuspendLayout();
+            this.mibGumpIdContextMenu.SuspendLayout();
+            this.tmapGroupBox.SuspendLayout();
             this.DmgDsplyGroup.SuspendLayout();
             this.uomodgroupbox.SuspendLayout();
             this.groupBox32.SuspendLayout();
@@ -2481,6 +2524,7 @@ namespace Assistant
             | System.Windows.Forms.AnchorStyles.Right)));
             this.FilterPages.Controls.Add(this.JournalFilterPage);
             this.FilterPages.Controls.Add(this.targettingTab);
+            this.FilterPages.Controls.Add(this.locationsFilterPage);
             this.FilterPages.Controls.Add(this.MiscFilterPage);
             this.FilterPages.Location = new System.Drawing.Point(-2, 2);
             this.FilterPages.Name = "FilterPages";
@@ -3334,6 +3378,211 @@ namespace Assistant
             this.targetlistBox.Size = new System.Drawing.Size(113, 130);
             this.targetlistBox.TabIndex = 0;
             this.targetlistBox.SelectedIndexChanged += new System.EventHandler(this.targetlistBox_SelectedIndexChanged);
+            // 
+            // locationsFilterPage
+            // 
+            this.locationsFilterPage.Controls.Add(this.sosGroupBox);
+            this.locationsFilterPage.Controls.Add(this.tmapGroupBox);
+            this.locationsFilterPage.Location = new System.Drawing.Point(4, 22);
+            this.locationsFilterPage.Name = "locationsFilterPage";
+            this.locationsFilterPage.Padding = new System.Windows.Forms.Padding(3);
+            this.locationsFilterPage.Size = new System.Drawing.Size(649, 345);
+            this.locationsFilterPage.TabIndex = 3;
+            this.locationsFilterPage.Text = "Locations";
+            this.locationsFilterPage.UseVisualStyleBackColor = true;
+            // 
+            // sosGroupBox
+            // 
+            this.sosGroupBox.Controls.Add(this.captureMibsCheckBox);
+            this.sosGroupBox.Controls.Add(this.mibPathTextBox);
+            this.sosGroupBox.Controls.Add(this.mibSetPathButton);
+            this.sosGroupBox.Controls.Add(this.mibClearPathButton);
+            this.sosGroupBox.Controls.Add(this.addXYToGumpCheckBox);
+            this.sosGroupBox.Controls.Add(this.mibGumpIdTextBox);
+            this.sosGroupBox.Controls.Add(this.mibGumpIdAddButton);
+            this.sosGroupBox.Controls.Add(this.mibGumpIdGroupBox);
+            this.sosGroupBox.Location = new System.Drawing.Point(6, 6);
+            this.sosGroupBox.Name = "sosGroupBox";
+            this.sosGroupBox.Size = new System.Drawing.Size(637, 130);
+            this.sosGroupBox.TabIndex = 0;
+            this.sosGroupBox.TabStop = false;
+            this.sosGroupBox.Text = "SOS\'s";
+            // 
+            // captureMibsCheckBox
+            // 
+            this.captureMibsCheckBox.AutoSize = true;
+            this.captureMibsCheckBox.Location = new System.Drawing.Point(6, 20);
+            this.captureMibsCheckBox.Name = "captureMibsCheckBox";
+            this.captureMibsCheckBox.Size = new System.Drawing.Size(135, 18);
+            this.captureMibsCheckBox.TabIndex = 0;
+            this.captureMibsCheckBox.Text = "Capture MIBs to file";
+            this.captureMibsCheckBox.UseVisualStyleBackColor = true;
+            this.captureMibsCheckBox.CheckedChanged += new System.EventHandler(this.captureMibsCheckBox_CheckedChanged);
+            // 
+            // mibPathTextBox
+            // 
+            this.mibPathTextBox.BackColor = System.Drawing.Color.White;
+            this.mibPathTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.mibPathTextBox.Location = new System.Drawing.Point(6, 44);
+            this.mibPathTextBox.Name = "mibPathTextBox";
+            this.mibPathTextBox.ReadOnly = true;
+            this.mibPathTextBox.Size = new System.Drawing.Size(216, 20);
+            this.mibPathTextBox.TabIndex = 1;
+            // 
+            // mibSetPathButton
+            // 
+            this.mibSetPathButton.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mibSetPathButton.Location = new System.Drawing.Point(228, 43);
+            this.mibSetPathButton.Name = "mibSetPathButton";
+            this.mibSetPathButton.Size = new System.Drawing.Size(75, 21);
+            this.mibSetPathButton.TabIndex = 2;
+            this.mibSetPathButton.Text = "Set Path";
+            this.mibSetPathButton.UseVisualStyleBackColor = true;
+            this.mibSetPathButton.Click += new System.EventHandler(this.mibSetPathButton_Click);
+            // 
+            // mibClearPathButton
+            // 
+            this.mibClearPathButton.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mibClearPathButton.Location = new System.Drawing.Point(228, 66);
+            this.mibClearPathButton.Name = "mibClearPathButton";
+            this.mibClearPathButton.Size = new System.Drawing.Size(75, 21);
+            this.mibClearPathButton.TabIndex = 8;
+            this.mibClearPathButton.Text = "Clear";
+            this.mibClearPathButton.UseVisualStyleBackColor = true;
+            this.mibClearPathButton.Click += new System.EventHandler(this.mibClearPathButton_Click);
+            // 
+            // addXYToGumpCheckBox
+            // 
+            this.addXYToGumpCheckBox.AutoSize = true;
+            this.addXYToGumpCheckBox.Location = new System.Drawing.Point(6, 70);
+            this.addXYToGumpCheckBox.Name = "addXYToGumpCheckBox";
+            this.addXYToGumpCheckBox.Size = new System.Drawing.Size(121, 18);
+            this.addXYToGumpCheckBox.TabIndex = 3;
+            this.addXYToGumpCheckBox.Text = "Add X,Y to Gump";
+            this.addXYToGumpCheckBox.UseVisualStyleBackColor = true;
+            this.addXYToGumpCheckBox.CheckedChanged += new System.EventHandler(this.addXYToGumpCheckBox_CheckedChanged);
+            // 
+            // mibGumpIdTextBox
+            // 
+            this.mibGumpIdTextBox.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mibGumpIdTextBox.Location = new System.Drawing.Point(6, 96);
+            this.mibGumpIdTextBox.Name = "mibGumpIdTextBox";
+            this.mibGumpIdTextBox.Size = new System.Drawing.Size(100, 20);
+            this.mibGumpIdTextBox.TabIndex = 4;
+            // 
+            // mibGumpIdAddButton
+            // 
+            this.mibGumpIdAddButton.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mibGumpIdAddButton.Location = new System.Drawing.Point(112, 95);
+            this.mibGumpIdAddButton.Name = "mibGumpIdAddButton";
+            this.mibGumpIdAddButton.Size = new System.Drawing.Size(55, 21);
+            this.mibGumpIdAddButton.TabIndex = 5;
+            this.mibGumpIdAddButton.Text = "Add ID";
+            this.mibGumpIdAddButton.UseVisualStyleBackColor = true;
+            this.mibGumpIdAddButton.Click += new System.EventHandler(this.mibGumpIdAddButton_Click);
+            // 
+            // mibGumpIdGroupBox
+            // 
+            this.mibGumpIdGroupBox.Controls.Add(this.mibGumpIdListBox);
+            this.mibGumpIdGroupBox.Location = new System.Drawing.Point(316, 10);
+            this.mibGumpIdGroupBox.Name = "mibGumpIdGroupBox";
+            this.mibGumpIdGroupBox.Size = new System.Drawing.Size(315, 115);
+            this.mibGumpIdGroupBox.TabIndex = 2;
+            this.mibGumpIdGroupBox.TabStop = false;
+            this.mibGumpIdGroupBox.Text = "SOS Gump IDs";
+            // 
+            // mibGumpIdListBox
+            // 
+            this.mibGumpIdListBox.ContextMenuStrip = this.mibGumpIdContextMenu;
+            this.mibGumpIdListBox.FormattingEnabled = true;
+            this.mibGumpIdListBox.ItemHeight = 14;
+            this.mibGumpIdListBox.Location = new System.Drawing.Point(6, 16);
+            this.mibGumpIdListBox.Name = "mibGumpIdListBox";
+            this.mibGumpIdListBox.Size = new System.Drawing.Size(303, 88);
+            this.mibGumpIdListBox.TabIndex = 0;
+            // 
+            // mibGumpIdContextMenu
+            // 
+            this.mibGumpIdContextMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.mibGumpIdContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mibGumpIdRemoveMenuItem});
+            this.mibGumpIdContextMenu.Name = "mibGumpIdContextMenu";
+            this.mibGumpIdContextMenu.Size = new System.Drawing.Size(118, 26);
+            // 
+            // mibGumpIdRemoveMenuItem
+            // 
+            this.mibGumpIdRemoveMenuItem.Name = "mibGumpIdRemoveMenuItem";
+            this.mibGumpIdRemoveMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.mibGumpIdRemoveMenuItem.Text = "Remove";
+            this.mibGumpIdRemoveMenuItem.Click += new System.EventHandler(this.mibGumpIdRemoveMenuItem_Click);
+            // 
+            // tmapGroupBox
+            // 
+            this.tmapGroupBox.Controls.Add(this.captureTmapsCheckBox);
+            this.tmapGroupBox.Controls.Add(this.tmapPathTextBox);
+            this.tmapGroupBox.Controls.Add(this.tmapSetPathButton);
+            this.tmapGroupBox.Controls.Add(this.tmapClearPathButton);
+            this.tmapGroupBox.Controls.Add(this.displayXYUnderMapCheckBox);
+            this.tmapGroupBox.Location = new System.Drawing.Point(6, 142);
+            this.tmapGroupBox.Name = "tmapGroupBox";
+            this.tmapGroupBox.Size = new System.Drawing.Size(310, 120);
+            this.tmapGroupBox.TabIndex = 1;
+            this.tmapGroupBox.TabStop = false;
+            this.tmapGroupBox.Text = "Treasure Maps";
+            // 
+            // captureTmapsCheckBox
+            // 
+            this.captureTmapsCheckBox.AutoSize = true;
+            this.captureTmapsCheckBox.Location = new System.Drawing.Point(6, 20);
+            this.captureTmapsCheckBox.Name = "captureTmapsCheckBox";
+            this.captureTmapsCheckBox.Size = new System.Drawing.Size(181, 18);
+            this.captureTmapsCheckBox.TabIndex = 0;
+            this.captureTmapsCheckBox.Text = "Capture Treasure Maps to File";
+            this.captureTmapsCheckBox.UseVisualStyleBackColor = true;
+            this.captureTmapsCheckBox.CheckedChanged += new System.EventHandler(this.captureTmapsCheckBox_CheckedChanged);
+            // 
+            // tmapPathTextBox
+            // 
+            this.tmapPathTextBox.BackColor = System.Drawing.Color.White;
+            this.tmapPathTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.tmapPathTextBox.Location = new System.Drawing.Point(6, 44);
+            this.tmapPathTextBox.Name = "tmapPathTextBox";
+            this.tmapPathTextBox.ReadOnly = true;
+            this.tmapPathTextBox.Size = new System.Drawing.Size(216, 20);
+            this.tmapPathTextBox.TabIndex = 1;
+            // 
+            // tmapSetPathButton
+            // 
+            this.tmapSetPathButton.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tmapSetPathButton.Location = new System.Drawing.Point(228, 43);
+            this.tmapSetPathButton.Name = "tmapSetPathButton";
+            this.tmapSetPathButton.Size = new System.Drawing.Size(75, 21);
+            this.tmapSetPathButton.TabIndex = 2;
+            this.tmapSetPathButton.Text = "Set Path";
+            this.tmapSetPathButton.UseVisualStyleBackColor = true;
+            this.tmapSetPathButton.Click += new System.EventHandler(this.tmapSetPathButton_Click);
+            // 
+            // tmapClearPathButton
+            // 
+            this.tmapClearPathButton.Font = new System.Drawing.Font("Arial", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tmapClearPathButton.Location = new System.Drawing.Point(228, 66);
+            this.tmapClearPathButton.Name = "tmapClearPathButton";
+            this.tmapClearPathButton.Size = new System.Drawing.Size(75, 21);
+            this.tmapClearPathButton.TabIndex = 4;
+            this.tmapClearPathButton.Text = "Clear";
+            this.tmapClearPathButton.UseVisualStyleBackColor = true;
+            this.tmapClearPathButton.Click += new System.EventHandler(this.tmapClearPathButton_Click);
+            // 
+            // displayXYUnderMapCheckBox
+            // 
+            this.displayXYUnderMapCheckBox.AutoSize = true;
+            this.displayXYUnderMapCheckBox.Location = new System.Drawing.Point(6, 70);
+            this.displayXYUnderMapCheckBox.Name = "displayXYUnderMapCheckBox";
+            this.displayXYUnderMapCheckBox.Size = new System.Drawing.Size(155, 18);
+            this.displayXYUnderMapCheckBox.TabIndex = 3;
+            this.displayXYUnderMapCheckBox.Text = "Display X, Y Under Map";
+            this.displayXYUnderMapCheckBox.UseVisualStyleBackColor = true;
+            this.displayXYUnderMapCheckBox.CheckedChanged += new System.EventHandler(this.displayXYUnderMapCheckBox_CheckedChanged);
             // 
             // MiscFilterPage
             // 
@@ -9801,6 +10050,13 @@ namespace Assistant
             this.groupBox43.ResumeLayout(false);
             this.groupBox43.PerformLayout();
             this.MiscFilterPage.ResumeLayout(false);
+            this.locationsFilterPage.ResumeLayout(false);
+            this.sosGroupBox.ResumeLayout(false);
+            this.sosGroupBox.PerformLayout();
+            this.mibGumpIdGroupBox.ResumeLayout(false);
+            this.mibGumpIdContextMenu.ResumeLayout(false);
+            this.tmapGroupBox.ResumeLayout(false);
+            this.tmapGroupBox.PerformLayout();
             this.DmgDsplyGroup.ResumeLayout(false);
             this.DmgDsplyGroup.PerformLayout();
             this.uomodgroupbox.ResumeLayout(false);


### PR DESCRIPTION
Added in a location sub taq to the filters tab. this tab will allow you to create csv for treasure maps and mibs respectfully. you can set your own path for them, or leave blank to use the main RE root directory. This will leave two separate .csvs for them, there is a setting to add more or remove gumpids in case the gumpid changes or is different for sos's. Also added buttons to show the x y on an sos gump when checked, and moved the treasure map setting that shows under it to its own check to have on or off.
Also fixed  a bug once you open a treasuremap if you open it it and move it it will still show the x y if its in memory still.