### PR TITLE
Fixed a bug happening when using "findfound" in macros. 

### DIFF
--- a/Razor/RazorEnhanced/Macros/Actions/TargetAction.cs
+++ b/Razor/RazorEnhanced/Macros/Actions/TargetAction.cs
@@ -183,7 +183,7 @@ namespace RazorEnhanced.Macros.Actions
                             return;
                         }
 
-                        int aliasSerial = (int)(uint)Misc.ReadSharedValue(AliasName.ToLower());
+                        int aliasSerial = Convert.ToInt32(Misc.ReadSharedValue(AliasName.ToLower()));
 
                         if (aliasSerial != 0 && aliasSerial != -1)
                         {

--- a/Razor/RazorEnhanced/Macros/Actions/TargetAction.cs
+++ b/Razor/RazorEnhanced/Macros/Actions/TargetAction.cs
@@ -183,7 +183,7 @@ namespace RazorEnhanced.Macros.Actions
                             return;
                         }
 
-                        int aliasSerial = (int)Misc.ReadSharedValue(AliasName.ToLower());
+                        int aliasSerial = (int)(uint)Misc.ReadSharedValue(AliasName.ToLower());
 
                         if (aliasSerial != 0 && aliasSerial != -1)
                         {


### PR DESCRIPTION
The target id is an uint stored in a object box and a direct cast to int will always fail.

The solution was to cast the object storing the id into an unit, then casting into a int.